### PR TITLE
修复Mac快捷键支持：自动检测系统，Mac用Cmd+Shift+E，Windows/Linux用Ctrl+Shift+E

### DIFF
--- a/Notion-Formula-Auto-Conversion-Tool-1.6.js
+++ b/Notion-Formula-Auto-Conversion-Tool-1.6.js
@@ -413,8 +413,9 @@
             document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
             await sleep(50);
 
-            // 使用 Ctrl+Shift+E 快捷键打开公式编辑器
-            await simulateShortcut('Ctrl+Shift+E');
+            // 使用快捷键打开公式编辑器（Mac 用 Cmd，Windows/Linux 用 Ctrl）
+            const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+            await simulateShortcut(isMac ? 'Meta+Shift+E' : 'Ctrl+Shift+E');
             // 等待公式编辑器出现，然后模拟 Enter 键确认
             await sleep(50);
 


### PR DESCRIPTION
修复Mac快捷键支持：自动检测系统，Mac用Cmd+Shift+E，Windows/Linux用Ctrl+Shift+E

解决了 https://github.com/skyance/Notion-Formula-Auto-Conversion-Tool/issues/3 这个 issue。